### PR TITLE
Fix initializeModels bug

### DIFF
--- a/.changeset/lucky-wolves-yawn.md
+++ b/.changeset/lucky-wolves-yawn.md
@@ -1,0 +1,5 @@
+---
+'@palmares/databases': patch
+---
+
+add a coverage to avoid errors on model initializing

--- a/packages/databases/src/models/utils.ts
+++ b/packages/databases/src/models/utils.ts
@@ -443,7 +443,8 @@ export async function initializeModels(
     if (engine.models.afterModelsTranslation) {
       const { modelEntries, modelsByName } = initializedModels.reduce(
         (acc, model) => {
-          if (model.original.options?.instance && (options || {}).forceTranslation !== true) return acc;
+          const optionsOfModel = model.class['_options']();
+          if (optionsOfModel && (options || {}).forceTranslation !== true) return acc;
           const modelName = model.class['__getName']();
           acc.modelsByName[modelName] = model;
           acc.modelEntries.push([modelName, model.initialized]);

--- a/packages/databases/src/models/utils.ts
+++ b/packages/databases/src/models/utils.ts
@@ -443,7 +443,7 @@ export async function initializeModels(
     if (engine.models.afterModelsTranslation) {
       const { modelEntries, modelsByName } = initializedModels.reduce(
         (acc, model) => {
-          if (model.original.options.instance && (options || {}).forceTranslation !== true) return acc;
+          if (model.original.options?.instance && (options || {}).forceTranslation !== true) return acc;
           const modelName = model.class['__getName']();
           acc.modelsByName[modelName] = model;
           acc.modelEntries.push([modelName, model.initialized]);


### PR DESCRIPTION
When setupping the databases library, i got this error
`if (model2.original.options.instance && (options || {}).forceTranslation !== true) return acc;`
`TypeError: Cannot read properties of undefined (reading 'instance')`
`at initializedModels.reduce.modelsByName`

And with an Optional Chaining, the condition gets falsy as expected, i supposed.