### PR TITLE
Fix in parser

### DIFF
--- a/.changeset/lucky-wolves-yawn.md
+++ b/.changeset/lucky-wolves-yawn.md
@@ -1,0 +1,5 @@
+---
+'@palmares/databases': patch
+---
+
+add a coverage to avoid errors on model initializing

--- a/packages/databases/src/models/utils.ts
+++ b/packages/databases/src/models/utils.ts
@@ -443,7 +443,8 @@ export async function initializeModels(
     if (engine.models.afterModelsTranslation) {
       const { modelEntries, modelsByName } = initializedModels.reduce(
         (acc, model) => {
-          if (model.original.options?.instance && (options || {}).forceTranslation !== true) return acc;
+          const optionsOfModel = model.class['_options']();
+          if (optionsOfModel && (options || {}).forceTranslation !== true) return acc;
           const modelName = model.class['__getName']();
           acc.modelsByName[modelName] = model;
           acc.modelEntries.push([modelName, model.initialized]);

--- a/packages/databases/src/models/utils.ts
+++ b/packages/databases/src/models/utils.ts
@@ -198,6 +198,7 @@ export function retrieveInputAndOutputParsersFromFieldAndCache(
   fieldName: string,
   field: Field<any, any, any>
 ) {
+  if (!field) return
   const existingOutputParser = field['__outputParsers'].get(engine.connectionName);
   const existingInputParser = field['__inputParsers'].get(engine.connectionName);
   if (existingOutputParser !== undefined && existingInputParser !== undefined) {

--- a/packages/databases/src/models/utils.ts
+++ b/packages/databases/src/models/utils.ts
@@ -443,7 +443,7 @@ export async function initializeModels(
     if (engine.models.afterModelsTranslation) {
       const { modelEntries, modelsByName } = initializedModels.reduce(
         (acc, model) => {
-          if (model.original.options.instance && (options || {}).forceTranslation !== true) return acc;
+          if (model.original.options?.instance && (options || {}).forceTranslation !== true) return acc;
           const modelName = model.class['__getName']();
           acc.modelsByName[modelName] = model;
           acc.modelEntries.push([modelName, model.initialized]);


### PR DESCRIPTION
Im was doing the @palmares/database setup, and when i run this query:
```ts
import './database.config';
import { Company, User } from './models';
await Company.default.set((qs) =>
  qs
    .join(User, 'usersOfCompany', (qs) =>
      qs.data(
        {
          firstName: 'Foo',
          lastName: 'bar',
          email: 'foo@bar.com',
          isActive: true,
        },
        {
          firstName: 'John',
          lastName: 'Doe',
          email: 'john@doe.com',
          isActive: true,
        }
      )
    )
    .data({
      name: 'Evil Foo',
      slug: 'evil-foo',
      isActive: true,
    })
);
```

i got this error:
 const existingOutputParser = field["__outputParsers"].get(engine.connectionName);
                                    ^
TypeError: Cannot read properties of undefined (reading '__outputParsers')
at retrieveInputAndOutputParsersFromFieldAndCache (C:\Users\Caio\Documents\develop\palmares-testing\node_modules\@palmares\databases\dist\src\index.js:3611:37)

```ts
  const existingOutputParser = field["__outputParsers"].get(engine.connectionName);
  const existingInputParser = field["__inputParsers"].get(engine.connectionName);
```
Using some console.log's, i see that field are getting undefined. So, in a fast solution, i added an 
`if (!field) return` in top of the function, and run my queries file, and its run fine at my database. But idk if is a optimal solution
