### PR TITLE
fix: unecessary serverless

### DIFF
--- a/.changeset/wild-worms-guess.md
+++ b/.changeset/wild-worms-guess.md
@@ -1,0 +1,5 @@
+---
+'@palmares/server': minor
+---
+
+fix: trigerring serverless at wrong time

--- a/packages/server/src/app/utils.ts
+++ b/packages/server/src/app/utils.ts
@@ -1047,7 +1047,7 @@ export async function initializeRouters(
       }
     });
     for await (const router of routers) {
-      if ((useServerless && router.handlers.has(method)) || router.handlers.get('all')) {
+      if ((useServerless && (router.handlers.has(method)) || router.handlers.get('all'))) {
         if (router.handlers.has(method))
           return (router.handlers.get(method) as any)?.handler(serverRequestAndResponseData);
         else return (router.handlers.get('all') as any)?.handler(serverRequestAndResponseData);


### PR DESCRIPTION
I was trying to make `examples/server-express-only` work. Since it was pretty broken, I started to go through https://github.com/nicolasmelo1/seedify-palmares/tree/main and paste code to test it granularly. 

I noticed that some of the domains were broken, triggering the following error:

```
/home/brenoliradev/repos/palmares/libs/express-adapter/dist/src/index.cjs:272
    const { req } = serverRequestAndResponseData;
            ^

TypeError: Cannot destructure property 'req' of 'serverRequestAndResponseData' as it is undefined.
    at CustomServerRequestAdapter.method (/home/brenoliradev/repos/palmares/libs/express-adapter/dist/src/index.cjs:272:13)
    at get method (/home/brenoliradev/repos/palmares/packages/server/dist/src/index.cjs:3161:44)
    at AsyncFunction.wrappedHandler (/home/brenoliradev/repos/palmares/packages/server/dist/src/index.cjs:4015:25)
    at async loadServer (/home/brenoliradev/repos/palmares/packages/server/dist/src/index.cjs:3831:7)
    at async initializeApp (/home/brenoliradev/repos/palmares/packages/core/dist/src/index.cjs:56:3)

Node.js v22.13.1
```

When I was exploring I noticed the following comparison: `if (useServerless && router.handlers.has(method) || router.handlers.get("all"))`  - For me, comparison seemed the problem since it was trigerring for the method "all" incorrectly. Just by updating to  `if (useServerless && (router.handlers.has(method) || router.handlers.get("all")))`  I could add `.all()` handlers just fine.

----

steps to reproduce: 
1. clone https://github.com/nicolasmelo1/seedify-palmares/tree/main
2. add any ".all()" handler 